### PR TITLE
Switch from GraphiQL to GraphQL Playground

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
     "@types/next-auth": "3.1.26",
     "eslint": "^7.28.0",
     "eslint-config-next": "^11.0.0",
+    "graphql-playground-html": "^1.6.29",
     "husky": "4.3.8",
     "prettier": "2.2.1",
     "pretty-quick": "3.1.0",

--- a/src/pages/api/graphql.ts
+++ b/src/pages/api/graphql.ts
@@ -1,9 +1,9 @@
 import {
   getGraphQLParameters,
   processRequest,
-  renderGraphiQL,
   shouldRenderGraphiQL,
 } from 'graphql-helix'
+import { renderPlaygroundPage } from 'graphql-playground-html'
 import { NextApiHandler } from 'next/types'
 import { schema } from '../../lib/nexus/schema'
 import { createContext, Context } from '../../lib/nexus/context'
@@ -17,22 +17,21 @@ export default (async (req, res) => {
   }
 
   if (shouldRenderGraphiQL(request)) {
-    res.send(renderGraphiQL({ endpoint: '/api/graphql' }))
-  } else {
-    const { operationName, query, variables } = getGraphQLParameters(request)
+    return res.send(renderPlaygroundPage({ endpoint: '/api/graphql' }))
+  }
+  const { operationName, query, variables } = getGraphQLParameters(request)
 
-    const result = await processRequest<Context>({
-      operationName,
-      query,
-      variables,
-      request,
-      schema,
-      contextFactory: () => createContext({ req }),
-    })
+  const result = await processRequest<Context>({
+    operationName,
+    query,
+    variables,
+    request,
+    schema,
+    contextFactory: () => createContext({ req }),
+  })
 
-    if (result.type === 'RESPONSE') {
-      result.headers.forEach(({ name, value }) => res.setHeader(name, value))
-      res.status(result.status).json(result.payload)
-    }
+  if (result.type === 'RESPONSE') {
+    result.headers.forEach(({ name, value }) => res.setHeader(name, value))
+    res.status(result.status).json(result.payload)
   }
 }) as NextApiHandler

--- a/yarn.lock
+++ b/yarn.lock
@@ -2114,6 +2114,11 @@ combined-stream@^1.0.8:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.20.3:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 common-tags@1.8.0, common-tags@^1.8.0:
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.8.0.tgz#8e3153e542d4a39e9b10554434afaaf98956a937"
@@ -2272,6 +2277,11 @@ css.escape@1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/css.escape/-/css.escape-1.5.1.tgz#42e27d4fa04ae32f931a4b4d4191fa9cddee97cb"
   integrity sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
+cssfilter@0.0.10:
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/cssfilter/-/cssfilter-0.0.10.tgz#c6d2672632a2e5c83e013e6864a42ce8defd20ae"
+  integrity sha1-xtJnJjKi5cg+AT5oZKQs6N79IK4=
 
 cssnano-preset-simple@^2.0.0:
   version "2.0.0"
@@ -3299,6 +3309,13 @@ graphql-helix@1.2.3:
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/graphql-helix/-/graphql-helix-1.2.3.tgz#eaad4db338e2cdf6f5799478d1b05125ff19cd04"
   integrity sha512-psBs23Md/Nt0qsNOv5K+MqqsJ09lTyYtoujGAlFuE1+twUBQiKyanOYk3cqs9BtnJ7JsS+JlsS2/0ceE+20RCA==
+
+graphql-playground-html@^1.6.29:
+  version "1.6.29"
+  resolved "https://registry.yarnpkg.com/graphql-playground-html/-/graphql-playground-html-1.6.29.tgz#5b0c60a0161cc0f3116085f64c5a16cb3b2d9a16"
+  integrity sha512-fbF/zZKuw2sdfKp8gjTORJ/I9xBsqeEYRseWxBzuR15NHMptRTT9414IyRCs3ognZzUDr5MDJgx97SlLZCtQyA==
+  dependencies:
+    xss "^1.0.6"
 
 graphql-request@^3.3.0:
   version "3.4.0"
@@ -6656,6 +6673,14 @@ xmlbuilder@~11.0.0:
   version "11.0.1"
   resolved "https://registry.yarnpkg.com/xmlbuilder/-/xmlbuilder-11.0.1.tgz#be9bae1c8a046e76b31127726347d0ad7002beb3"
   integrity sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA==
+
+xss@^1.0.6:
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/xss/-/xss-1.0.9.tgz#3ffd565571ff60d2e40db7f3b80b4677bec770d2"
+  integrity sha512-2t7FahYnGJys6DpHLhajusId7R0Pm2yTmuL0GV9+mV0ZlaLSnb2toBmppATfg5sWIhZQGlsTLoecSzya+l4EAQ==
+  dependencies:
+    commander "^2.20.3"
+    cssfilter "0.0.10"
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
Since GraphQL Playground is a better version of GraphiQL I think we should switch for more features.
(Playground is especially great for including credentials on GraphQL requests in development)